### PR TITLE
[PSE-106] Use Media Priorization when the layout changes

### DIFF
--- a/web/js/helpers/OTHelper.js
+++ b/web/js/helpers/OTHelper.js
@@ -8,10 +8,16 @@
   // loading it statically.
   if (dynamicOTLoad) {
     var OPENTOK_API = 'https://static.opentok.com/webrtc/v2/js/opentok.min.js';
-    otPromise = LazyLoader.load(OPENTOK_API);
+    otPromise = LazyLoader.load(OPENTOK_API,
+                                './resolutionAlgorithms.js');
   } else {
-    otPromise = Promise.resolve();
+    otPromise = LazyLoader.load('/js/helpers/resolutionAlgorithms.js');
   }
+
+  var PrefResolutionAlgProv;
+  otPromise.then(function () {
+    PrefResolutionAlgProv= exports.PreferredResolutionAlgorithmProvider;
+  });
 
   var MSG_MULTIPART = 'signal';
   var SIZE_MAX = 7800;
@@ -339,62 +345,11 @@
     });
   }
 
-  // PreferredResolution algorithms. They all take as input the total screen real state available,
-  // the available real state for the subscriber being redimensioned, the maximum dimensions of the
-  // stream and the number of current subscribers. And based on that it returns the new recommended
-  // preferred resolution dimension. All the dimensions are objects that have both a width and
-  // height attributes
-  var preferedResolutionAlgorithms = {
-    // Assuming all the subscribers share a common DOM parent, we can calculate which percent of the
-    // whole size we're taking, and thus restrict the stream size...
-    percentOfAvailable: function(aStreamDimension, aTotalDimension, aSubsDimension, aSubsNumber) {
-      // Assumption: All the subscribers have the same size. What we're going to do is to assign a
-      // % of the total pool of pixels available (as sent, not as shown):
-      var totalWidth = aStreamDimension.width * aSubsNumber;
-      var totalHeight = aStreamDimension.height * aSubsNumber;
-      return {
-        width: Math.ceil(totalWidth * aSubsDimension.width / aTotalDimension.width),
-        height: Math.ceil(totalHeight * aSubsDimension.height / aTotalDimension.height)
-      };
-    },
-
-    // Assign a % of the actual stream size (as sent, not as shown):
-    percentOfStream: function(aStreamDimension, aTotalDimension, aSubsDimension, aSubsNumber) {
-      var totalWidth = aStreamDimension.width;
-      var totalHeight = aStreamDimension.height;
-      var percentW = aSubsDimension.width / aTotalDimension.width;
-      var percentH = aSubsDimension.height / aTotalDimension.height;
-      return {
-        width: Math.ceil(totalWidth * percentW),
-        height: Math.ceil(totalHeight * percentH)
-      };
-    },
-
-    // like percentOfStream but once we're over 70% on any of the dimensions, we just assign the
-    // maximum size on both dimensions.
-    biasedPercent: function(aStreamDimension, aTotalDimension, aSubsDimension, aSubsNumber) {
-      var totalWidth = aStreamDimension.width;
-      var totalHeight = aStreamDimension.height;
-      var percentW = aSubsDimension.width / aTotalDimension.width;
-      var percentH = aSubsDimension.height / aTotalDimension.height;
-      if (percentH >= 0.70 || percentW >= 0.70) {
-        percentH = 1;
-        percentW = 1;
-      }
-      return {
-        width: Math.ceil(totalWidth * percentW),
-        height: Math.ceil(totalHeight * percentH)
-      };
-    }
-  };
-  var defaultAlgorithm = 'biasedPercent';
-
   function setPreferredResolution(aSubscriber, aTotalDimension, aSubsDimension,
                                  aSubsNumber, aAlgorithm) {
-    var chosenAlgorithm =
-      aAlgorithm && preferedResolutionAlgorithms[aAlgorithm] && aAlgorithm ||
-      defaultAlgorithm;
-    var algorithm = preferedResolutionAlgorithms[chosenAlgorithm];
+    var algInfo = PrefResolutionAlgProv.getAlg(aAlgorithm);
+    var chosenAlgorithm = algInfo.chosenAlgorithm;
+    var algorithm = algInfo.algorithm;
     var streamDimension = aSubscriber.stream.videoDimensions;
     var newDimension =
       algorithm(streamDimension, aTotalDimension, aSubsDimension, aSubsNumber);

--- a/web/js/helpers/resolutionAlgorithms.js
+++ b/web/js/helpers/resolutionAlgorithms.js
@@ -1,0 +1,65 @@
+!function(exports) {
+
+  // PreferredResolution algorithms. They all take as input the total screen real state available,
+  // the available real state for the subscriber being redimensioned, the maximum dimensions of the
+  // stream and the number of current subscribers. And based on that it returns the new recommended
+  // preferred resolution dimension. All the dimensions are objects that have both a width and
+  // height attributes
+  var preferredResolutionAlgorithms = {
+    // Assuming all the subscribers share a common DOM parent, we can calculate which percent of the
+    // whole size we're taking, and thus restrict the stream size...
+    percentOfAvailable: function(aStreamDimension, aTotalDimension, aSubsDimension, aSubsNumber) {
+      // Assumption: All the subscribers have the same size. What we're going to do is to assign a
+      // % of the total pool of pixels available (as sent, not as shown):
+      var totalWidth = aStreamDimension.width * aSubsNumber;
+      var totalHeight = aStreamDimension.height * aSubsNumber;
+      return {
+        width: Math.ceil(totalWidth * aSubsDimension.width / aTotalDimension.width),
+        height: Math.ceil(totalHeight * aSubsDimension.height / aTotalDimension.height)
+      };
+    },
+
+    // Assign a % of the actual stream size (as sent, not as shown):
+    percentOfStream: function(aStreamDimension, aTotalDimension, aSubsDimension, aSubsNumber) {
+      var totalWidth = aStreamDimension.width;
+      var totalHeight = aStreamDimension.height;
+      var percentW = aSubsDimension.width / aTotalDimension.width;
+      var percentH = aSubsDimension.height / aTotalDimension.height;
+      return {
+        width: Math.ceil(totalWidth * percentW),
+        height: Math.ceil(totalHeight * percentH)
+      };
+    },
+
+    // like percentOfStream but once we're over 70% on any of the dimensions, we just assign the
+    // maximum size on both dimensions.
+    biasedPercent: function(aStreamDimension, aTotalDimension, aSubsDimension, aSubsNumber) {
+      var totalWidth = aStreamDimension.width;
+      var totalHeight = aStreamDimension.height;
+      var percentW = aSubsDimension.width / aTotalDimension.width;
+      var percentH = aSubsDimension.height / aTotalDimension.height;
+      if (percentH >= 0.70 || percentW >= 0.70) {
+        percentH = 1;
+        percentW = 1;
+      }
+      return {
+        width: Math.ceil(totalWidth * percentW),
+        height: Math.ceil(totalHeight * percentH)
+      };
+    }
+  };
+  var defaultAlgorithm = 'biasedPercent';
+
+  exports.PreferredResolutionAlgorithmProvider = {
+    getAlg: function(aAlgorithm) {
+      var chosenAlgorithm =
+        preferredResolutionAlgorithms[aAlgorithm] && aAlgorithm ||
+        defaultAlgorithm;
+      return {
+        chosenAlgorithm: chosenAlgorithm,
+        algorithm: preferredResolutionAlgorithms[chosenAlgorithm]
+      };
+    }
+  };
+
+}(this);

--- a/web/js/layoutManager.js
+++ b/web/js/layoutManager.js
@@ -85,7 +85,7 @@
     rearrange();
   }
 
-  function getElementById(aId) {
+  function getItemById(aId) {
     return items[aId];
   }
 
@@ -143,7 +143,7 @@
     init: init,
     append: append,
     remove: remove,
-    getElementById: getElementById
+    getItemById: getItemById
   };
 
 }(this);

--- a/web/js/libs/browser_utils.js
+++ b/web/js/libs/browser_utils.js
@@ -64,7 +64,7 @@
   // more than once on the search
   var parseSearch = function(aSearchStr) {
     return aSearchStr.slice(1).split('&').
-      map(function(aParam) { return aParam.split('=');}).
+      map(function(aParam) { return aParam.split('='); }).
       reduce(function(aObject, aCurrentValue) {
         var parName = aCurrentValue[0];
         aObject.params[parName] = _addValue(aObject.params[parName], aCurrentValue[1]);

--- a/web/js/roomController.js
+++ b/web/js/roomController.js
@@ -119,7 +119,7 @@
   // work all that well either.
   var processMutation = function(aMutation) {
     var elem = aMutation.target;
-    if ((aMutation.attributeName !== 'style' && aMutation.attributeName !== 'class')||
+    if ((aMutation.attributeName !== 'style' && aMutation.attributeName !== 'class') ||
         elem.dataset.streamType !== 'camera') {
       return;
     }
@@ -142,8 +142,9 @@
               var sub = window.subscriber[aSub];
               var stream = sub && sub.stream;
               var vd = stream && stream.videoDimensions;
-              var streamPref = stream && stream.getPreferredResolution();
-              sub && stream && console.log(
+              var streamPref = stream && stream.getPreferredResolution() ||
+                                 {width: 'NA', height: 'NA'};
+              stream && console.log(
                 "StreamId:", aSub, 'Real:', sub.videoWidth(), 'x', sub.videoHeight(),
                 'Stream.getPreferredResolution:', streamPref.width, 'x', streamPref.height,
                 'Stream.VDimension:', vd.width, 'x', vd.height
@@ -383,7 +384,7 @@
       subOptions.subscribeToVideo = !enterWithVideoDisabled;
 
       // We want to observe the container where the actual suscriber will live
-      var subsContainer = LayoutManager.getElementById(streamId);
+      var subsContainer = LayoutManager.getItemById(streamId);
       subsContainer && _mutationObserver &&
         _mutationObserver.observe(subsContainer, {attributes: true});
       subscriberStreams[streamId].subscriberPromise =


### PR DESCRIPTION
This isn't done yet. 
- The unit tests are missing (I know, I know, bad example all around :P)
- I want to play some more with possible algorithms
- And at some point disable the debug mode
- And of course, document the new parameters at the README

but I want to land this ASAP so I don't have to keep rebasing and I can involve some of the server people to see why it's ignoring the set resolution.

This adds two parameters:
- resolutionAlgorithm
- debugPreferredResolution

They're optional. The first one allows to select which algorithm to actually use for selecting a resolution. And the second one exports the stream information into Window and a handy dump function.
