### PR TITLE
Add snoop to opentokdemo

### DIFF
--- a/views/room.ejs
+++ b/views/room.ejs
@@ -13,6 +13,7 @@
     <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/<%=chromeExtensionId%>">
 
     <script type="text/javascript" src="https://static.opentok.com/webrtc/v2/js/opentok.min.js"></script>
+    <script type="text/javascript" src="https://d3brof7fu9hlhe.cloudfront.net/static/snoop.js"></script>
     <script defer src="/js/vendor/es6-promise.min.js"></script>
     <script defer type="text/javascript" src="/js/ie_polyfills.js"></script>
     <script defer src="/js/vendor/ZeroClipboard.min.js"></script>


### PR DESCRIPTION
This has been added to meet.tokbox.com already too.  It is a new tool/experiment to monitor more closely all the WebRTC stats/logs.   

It should be transparent for any app that uses it, but let us know if you find any issue.
