### PR TITLE
MODIFY parse query params with equals in the value

### DIFF
--- a/web/js/libs/browser_utils.js
+++ b/web/js/libs/browser_utils.js
@@ -80,7 +80,7 @@
   var parseSearch = function(aSearchStr) {
     aSearchStr = decodeStr(aSearchStr);
     return aSearchStr.slice(1).split('&').
-      map(function(aParam) { return aParam.split('='); }).
+      map(function(aParam) { return aParam.split(/=(.+)?/); }).
       reduce(function(aObject, aCurrentValue) {
         var parName = aCurrentValue[0];
         aObject.params[parName] = _addValue(aObject.params[parName], aCurrentValue[1] || null);


### PR DESCRIPTION
Parsing was failing if the userName value had equals (or any other value passed in the url, for example an opentok token).
I would prefer to just use jquery and not maintain this code but I'm sure you won't accept my PR in that case :P
