### PR TITLE
PSE-847 - Texto en el chat de Opentokdemo está indentado a la derecha…

### DIFF
--- a/web/less/chat.less
+++ b/web/less/chat.less
@@ -105,10 +105,6 @@
 
         p.yourself {
           text-align: right;
-
-          & > p {
-            text-align: left;
-          }
         }
 
         a {


### PR DESCRIPTION
…, no se puede leer bien