### PR TITLE
removed AvantGuard proprietary font

### DIFF
--- a/web/less/base.less
+++ b/web/less/base.less
@@ -107,7 +107,7 @@ label {
 }
 
 input, textarea {
-  font-family: "AvantGardeGothicITCW01B 731069", arial;
+  font-family: @muliRegularFont, arial;
 
   display: inline-block;
 

--- a/web/less/buttons.less
+++ b/web/less/buttons.less
@@ -1,7 +1,7 @@
 .btn,
 .btn-no-underline,
 .btn-padding {
-  font-family: "AvantGardeGothicITCW01B 731069", arial;
+  font-family: @muliRegularFont, arial;
   font-stretch: normal;
   font-style: normal;
   font-variant: normal;

--- a/web/less/endMeeting.less
+++ b/web/less/endMeeting.less
@@ -2,7 +2,7 @@
 
 @archivesBorderColor: #c5bbb4;
 @backgroundColor: #fff;
-@gardeGothicFont: "AvantGardeGothicITCW01X", arial;
+@gardeGothicFont: @muliRegularFont, arial;
 
 .endMeeting {
   height: 100%;

--- a/web/less/landing.less
+++ b/web/less/landing.less
@@ -47,7 +47,7 @@ body {
   }
 
   h1, h2, h3 {
-    font-family: "AvantGardeGothicITCW01X", arial;
+    font-family: @muliRegularFont, arial;
     padding: 0;
   }
 
@@ -140,7 +140,7 @@ body {
     }
 
     .tb.btn {
-      font-family: "AvantGardeGothicITCW01B 731069", arial;
+      font-family: @muliRegularFont, arial;
       font-size: 16px;
       @media @smartphones {
         font-size: 14px;

--- a/web/less/room.less
+++ b/web/less/room.less
@@ -137,7 +137,7 @@ body {
       position: relative;
       word-break: break-all;
       overflow: hidden;
-      font-family: "AvantGardeGothicITCW01X", arial;
+      font-family: @muliRegularFont, arial;
       font-size: 24px;
       font-weight: 100;
       line-height: 28px;
@@ -447,7 +447,7 @@ body {
   }
 
   header {
-    font-family: "AvantGardeGothicITCW01X", arial;
+    font-family: @muliRegularFont, arial;
     font-size: 48px;
     font-weight: 200;
     line-height: 60px;
@@ -461,7 +461,7 @@ body {
   }
 
   p {
-    font-family: "AvantGardeGothicITCW01M 731087", arial;
+    font-family: @muliRegularFont, arial;
     font-size: 16px;
     color: #5f6062;
   }
@@ -481,7 +481,7 @@ body {
   max-width: none;
 
   header {
-    font-family: "AvantGardeGothicITCW01X", arial;
+    font-family: @muliRegularFont, arial;
     font-size: 32px;
     font-weight: 200;
     line-height: 44px;
@@ -491,7 +491,7 @@ body {
   }
 
   section {
-    font-family: "AvantGardeGothicITCW01M 731087", arial;
+    font-family: @muliRegularFont, arial;
     font-size: 16px;
     color: #5f6062;
     text-align: left;
@@ -514,7 +514,7 @@ body {
   .tc-dropdown {
     select, span {
       background-color: transparent;
-      font-family: "AvantGardeGothicITCW01B 731069", arial;
+      font-family: @muliRegularFont, arial;
       border: 1px solid #c5bbb4;
       padding: 12px 10px;
       font-size: 16px;


### PR DESCRIPTION
Based on conversation with Liz, we would like to replace AvantGuard with Muli until the UI/UX redesign project can be taken on. This will remove the dependency on the AvantGuard proprietary font. There should be a follow up PR to remove the font AvantGuard font files from this repo