### PR TITLE
[Bugfix] Handle end call with no archive recorder model

### DIFF
--- a/web/js/endCallView.js
+++ b/web/js/endCallView.js
@@ -60,8 +60,11 @@
 
   var eventHandlers = {
     'EndCallController:endCall': function(evt) {
-      _model.addEventListener('value', render);
-      render(_model.archives);
+      if (_model) {
+        _model.addEventListener('value', render);
+        render(_model.archives);
+      }
+      render();
     }
   };
 


### PR DESCRIPTION
The PR which allowed firebase to be optional broke the endCallView if the recordings manager/firebase archives wasn't used as the model is undefined.
