### PR TITLE
ECO-347 - Use `document.body.clientWidth` instead of `screen.width`

### DIFF
--- a/views/room.ejs
+++ b/views/room.ejs
@@ -35,7 +35,7 @@
       var hiddenWhenExpanded = ['buttonContactItem'];
 
       var isMenuCollapsed = function() {
-        return screen.width < 770;
+        return document.body.clientWidth < 770;
          // Consider iPad portrait (768) not width enough to show the menu expanded
       }
 


### PR DESCRIPTION
#### What is this PR doing?

Using `document.body.clientWidth` instead of `screen.width` for determining when to minimize the sidebar. `screen.width` doesn't update when you resize the window. `document.body.clientWidth` is a better value to use. 

#### How should this be manually tested?

1. Open up a room
2. Make the window less than 770px wide

Expected result: The sidebar should minimize.

#### What are the relevant tickets?

ECO-347