### PR TITLE
ECO-352 - Show and hide the controls on mouseover

### DIFF
--- a/web/js/layoutView.js
+++ b/web/js/layoutView.js
@@ -27,10 +27,16 @@
       controls.classList.add('controls');
       this.appendControlElems(id, type, controls, options.controlElems, 'i');
       this.appendAdditionalUI(id, item, type, options.name);
+      var buttons = controls.querySelector('.buttons');
       this.container.addEventListener('touchend', function() {
-        var buttons = controls.querySelector('.buttons');
         var currentOpacity = buttons.style.opacity;
         buttons.style.opacity = buttons.style.opacity == 0 ? 1 : 0;
+      });
+      this.container.addEventListener('mouseover', function() {
+        buttons.style.opacity = 1;
+      });
+      this.container.addEventListener('mouseout', function() {
+        buttons.style.opacity = 0;
       });
       // Streams go inside <span> because of OpenTok overrides <li> styles if this
       // one would be the container.


### PR DESCRIPTION
#### What is this PR doing?

Showing and hiding the publisher and subscriber controls on mouseover. They were only being shown on touchend which doesn't work on Desktop. So on Desktop if you resize the window small you weren't able to click the mute buttons.

#### How should this be manually tested?

1. Open up a room in 2 tabs so that you have 2 participants.
2. Make the window less than 770px wide so that we go into the smaller responsive UI and the controls on the publisher and subscriber disappear. 

Expected result: The controls on the publisher and subscriber should appear when you mouseover the video area.

#### What are the relevant tickets?

ECO-352