### PR TITLE
ECO-351 - fix padding on sidebar switches for tight view

### DIFF
--- a/web/less/room.less
+++ b/web/less/room.less
@@ -252,6 +252,9 @@ body {
 
     .tc-list li.tight {
       padding: 0 0 2px 40px;
+      @media @smartphones {
+        padding: 3px 0 3px 12px;
+      }
 
       a {
         line-height: 30px;


### PR DESCRIPTION
#### What is this PR doing?

Fixing the padding on the mute video and mute audio switches at the bottom of the sidebar when it is minimized.

#### How should this be manually tested?

1. Open up a room
2. Make the window less than 770px wide
3. Minimize the sidebar (if it isn't already)

Expected result: You should be able to see the switches on the left hand side at the bottom.

#### What are the relevant tickets?

ECO-351
