### PR TITLE
ECO-347 - Fix menu expand/collapse sizing.

### DIFF
--- a/views/room.ejs
+++ b/views/room.ejs
@@ -35,7 +35,7 @@
       var hiddenWhenExpanded = ['buttonContactItem'];
 
       var isMenuCollapsed = function() {
-        return document.body.clientWidth < 770;
+        return window.innerWidth < 770;
          // Consider iPad portrait (768) not width enough to show the menu expanded
       }
 


### PR DESCRIPTION
The menu was improperly collapse upon loading the room in a browser
wider than the threshold.