### PR TITLE
HOTFIX: Individual Archiving

### DIFF
--- a/server/serverMethods.js
+++ b/server/serverMethods.js
@@ -501,7 +501,7 @@ function ServerMethods(aLogLevel, aModules) {
         switch (operation) {
           case 'startIndividual':
             archiveOptions.outputMode = 'individual';
-            break;
+            // falls through
           case 'startComposite':
             logger.log('Binding archiveOp to startArchive with sessionId:', sessionInfo.sessionId);
             archiveOp =


### PR DESCRIPTION
When fixing style I added a `break;` to a switch-case, as prompted by the linter error, but the fallthrough was intentional and this 'broke' the functionality. 

I have removed the `break` to restore functionality and...
To avoid the linter error, make this behaviour obvious, and not use `//eslint-disable-line` I added a comment `// falls through` which is picked up by regex and removes the linter error as specified in:
http://eslint.org/docs/rules/no-fallthrough


I can confirm the test for individual archiving is passing again after this change: 
```
  OpenTokRTC server
    ✓ GET /room/:roomName/info (56ms)
    ✓ GET /room/:roomName/info, roomName should ignore caps
    ✓ GET /room/:roomName/info?userName=xxxYYY
    ✓ GET /room/:roomName
    ✓ GET /room/:roomName?template=room
    ✓ GET /room/:roomName?template=unknownTemplate without auth, return default
    ✓ GET /room/:roomName?template=unknownTemplate&template_auth=1234 invalid auth
    ✓ GET /room/:roomName?template=unknownTemplate&template_auth=123456 valid auth
    ✓ POST /room/:roomName/archive should allow composite archiving
    ✓ POST /room/:roomName/archive should allow stopping the archive
    ✓ POST /room/:roomName/archive should allow individual archiving
    ✓ GET /archive/:archiveId
    ✓ DELETE /archive/:archiveId
    ✓ POST /updateArchiveInfo
    ✓ GET /room/:roomName/archive should return 404 for not existing archive
  15 passing (836ms)

```
