### PR TITLE
Update node version per Heroku recommendation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenTok RTC sample application to show off the OpenTok API and platform capabilities ",
   "main": "server.js",
   "engines": {
-    "node": "4.1.x",
+    "node": "4.8.x",
     "npm": "2.14.x"
   },
   "scripts": {
@@ -49,7 +49,7 @@
     "ioredis": "^1.7.6",
     "lodash": "^4.17.4",
     "opentok": "^2.3.0",
-    "swagger-boilerplate": "^0.0.8",
+    "swagger-boilerplate": "^0.0.9",
     "yamljs": "^0.2.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Please note that node 8 *should* work correctly also, but this is the minimum recommended change.