### PR TITLE
Feedback logging fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,11 +357,16 @@ sharing](tokbox.com/developer/guides/screen-sharing/).
 
 #### Feedback
 
- `ENABLE_FEEDBACK`: Enable the "Give Demo Feedback" form.
+The app lets the developer POST feedback data to an endpoint on your HTTP server:
+
+ `FEEDBACK_URL`: The URL to send a POST request with feedback data. Leave this as an empty string or
+ undefined to disable issue reporting.
+ 
  `REPORT_ISSUE_LEVEL`: The audio and video scores in the feedback form are between 1 (awful) and 5 (excellent). When the feedback form is submitted, if an audio or video score is less than or equal to the report issue level, the app calls `OT.reportIssue()`. This reports an issue, which you can view in OpenTok Inspector. (For more information, see [Reporting an issue](https://tokbox.com/developer/guides/debugging/js/#report-issue) in the OpenTok developer Guides.) The default value is 3, set to 0 to disable issue reporting.
+
  ```json
  "Feedback": {
-     "enabled": true,
+     "url": "",
      "reportIssueLevel": 0
  },
  ```
@@ -431,7 +436,7 @@ endpoint sends a response with the HTTP status code set to 200 and the JSON like
 ```json
 {
   "name": "opentok-rtc",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "gitHash": "312903cd043d5267bc11639718c47a9b313c1663",
   "opentok": true,
   "firebase": true,
@@ -466,7 +471,7 @@ the HTTP status code set 400 and JSON like the following:
 ```json
 {
   "name": "opentok-rtc",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "git_hash": "312903cd043d5267bc11639718c47a9b313c1663",
   "opentok": true,
   "firebase": false,

--- a/config/example.json
+++ b/config/example.json
@@ -15,7 +15,7 @@
       }
    },
    "Feedback":{
-     "enabled": false,
+     "url": "",
      "reportIssueLevel": 0
    },
    "Screensharing":{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-rtc",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-rtc",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "OpenTokRTC sample application to show off the OpenTok API and platform capabilities ",
   "main": "server.js",
   "engines": {

--- a/server/serverConstants.js
+++ b/server/serverConstants.js
@@ -57,7 +57,7 @@ E.ENABLE_ARCHIVE_MANAGER = { envVar: 'ENABLE_ARCHIVE_MANAGER', jsonPath: 'Archiv
 // Maximum time an empty room will keep it's history alive, in minutes.
 E.EMPTY_ROOM_LIFETIME = { envVar: 'EMPTY_ROOM_LIFETIME', jsonPath: 'Archiving.archiveManager.emptyRoomMaxLifetime', defaultValue: 3 };
 
-E.ENABLE_FEEDBACK = { envVar: 'ENABLE_FEEDBACK', jsonPath: 'Feedback.enabled', defaultValue: false, parser: parseBool };
+E.FEEDBACK_URL = { envVar: 'FEEDBACK_URL', jsonPath: 'Feedback.url', defaultValue: '' };
 
 E.REPORT_ISSUE_LEVEL = { envVar: 'REPORT_ISSUE_LEVEL', jsonPath: 'Feedback.reportIssueLevel', defaultValue: 3 };
 

--- a/server/serverMethods.js
+++ b/server/serverMethods.js
@@ -140,7 +140,7 @@ function ServerMethods(aLogLevel, aModules) {
       var enableArchiveManager = enableArchiving && config.get(C.ENABLE_ARCHIVE_MANAGER);
       var enableScreensharing = config.get(C.ENABLE_SCREENSHARING);
       var enableAnnotations = enableScreensharing && config.get(C.ENABLE_ANNOTATIONS);
-      var enableFeedback = config.get(C.ENABLE_FEEDBACK);
+      var feedbackUrl = config.get(C.FEEDBACK_URL);
       var reportIssueLevel = config.get(C.REPORT_ISSUE_LEVEL);
 
       if (!firebaseConfigured && enableArchiveManager) {
@@ -179,7 +179,7 @@ function ServerMethods(aLogLevel, aModules) {
                 enableArchiveManager,
                 enableScreensharing,
                 enableAnnotations,
-                enableFeedback,
+                feedbackUrl,
                 enableSip,
                 opentokJsUrl,
                 showTos,
@@ -340,7 +340,7 @@ function ServerMethods(aLogLevel, aModules) {
           enableArchiveManager: tbConfig.enableArchiveManager,
           enableScreensharing: tbConfig.enableScreensharing,
           enableAnnotation: tbConfig.enableAnnotations,
-          enableFeedback: tbConfig.enableFeedback,
+          feedbackUrl: tbConfig.feedbackUrl,
           precallSessionId: testSession.sessionId,
           apiKey: tbConfig.apiKey,
           precallToken: tbConfig.otInstance.generateToken(testSession.sessionId, {

--- a/test/unit/feedbackController_spec.js
+++ b/test/unit/feedbackController_spec.js
@@ -51,26 +51,51 @@ describe('FeedbackController', () => {
     }));
   });
 
+  // Fix
   describe('#feedbackView:sendFeedback event', () => {
     it('should send feedback event', sinon.test(function () {
-      var logEventStub = this.stub(window.OT.analytics, 'logEvent', (aLoggedEvent) => {});
+      var xhr = sinon.useFakeXMLHttpRequest();
+      var requests = this.requests = [];
       var report = {
         audioScore: 1,
         videoScore: 2,
         description: 'description',
       };
-      window.dispatchEvent(new CustomEvent('feedbackView:sendFeedback', { detail: report }));
-      expect(logEventStub.calledOnce).to.be.true;
-      expect(logEventStub.calledWith({
+      var timestamp = new Date().getTime();
+      var sourceUrl = document.location.href;
+
+      xhr.onCreate = function (xhr) {
+        requests.push(xhr);
+      };
+
+      var expectedRequestBody = {
         action: 'SessionQuality',
         partnerId: fakeOTHelper.session.apiKey,
         sessionId: fakeOTHelper.session.id,
         connectionId: fakeOTHelper.session.connection.id,
         publisherId: fakeOTHelper.publisherId,
+        clientSystemTime: timestamp,
+        source: sourceUrl,
         audioScore: report.audioScore,
         videoScore: report.videoScore,
         description: report.description,
-      })).to.be.true;
+      };
+
+      window.dispatchEvent(new CustomEvent('feedbackView:sendFeedback', { detail: report }));
+      expect(requests.length).to.equal(1);
+      expect(requests[0].method).to.equal('POST');
+      var requestBodyObj = JSON.parse(requests[0].requestBody);
+      expect(requestBodyObj.action).to.equal('SessionQuality');
+      expect(requestBodyObj.partnerId).to.equal(fakeOTHelper.session.apiKey);
+      expect(requestBodyObj.sessionId).to.equal(fakeOTHelper.session.id);
+      expect(requestBodyObj.connectionId).to.equal(fakeOTHelper.session.connection.id);
+      expect(requestBodyObj.publisherId).to.equal(fakeOTHelper.publisherId);
+      expect(requestBodyObj.clientSystemTime).to.equal(timestamp);
+      expect(requestBodyObj.source).to.equal(sourceUrl);
+      expect(requestBodyObj.audioScore).to.equal(report.audioScore);
+      expect(requestBodyObj.videoScore).to.equal(report.videoScore);
+      expect(requestBodyObj.description).to.equal(report.description);
+      xhr.restore();
     }));
   });
 

--- a/test/unit/roomView_spec.html
+++ b/test/unit/roomView_spec.html
@@ -94,7 +94,7 @@
   </div>
 </section>
 
-<% if (enableFeedback) { %>
+<% if (feedbackUrl) { %>
   <section class="feedbackButton">
     <span id="showFeedback">Feedback / Report a Bug</span>
   </section>

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -30,6 +30,7 @@
       window.precallToken='<%=precallToken%>';
       window.showTos=<%=showTos%> && !sessionStorage.tosAccepted;
       window.opentokJsUrl='<%=opentokJsUrl%>';
+      window.feedbackUrl = '<%=feedbackUrl%>';
       var isMobile = function() { return typeof window.orientation !== 'undefined'; }
 
       var mobileSettings = function() {
@@ -158,7 +159,7 @@
       </div>
     </section>
 
-    <% if (enableFeedback) { %>
+    <% if (feedbackUrl) { %>
       <section class="feedbackButton">
         <span id="showFeedback">Feedback / Report a Bug</span>
       </section>

--- a/web/js/feedbackController.js
+++ b/web/js/feedbackController.js
@@ -16,9 +16,14 @@
         publisherId: otHelper.publisherId,
         audioScore: report.audioScore,
         videoScore: report.videoScore,
-        description: report.description
+        description: report.description,
+        clientSystemTime: new Date().getTime(),
+        source: document.location.href
       };
-      OT.analytics.logEvent(loggedEvent);
+      var xhr = new XMLHttpRequest();
+      var url = window.feedbackUrl;
+      xhr.open('POST', url, true);
+      xhr.send(JSON.stringify(loggedEvent));
     },
     reportIssue: function () {
       var loggedEvent = {


### PR DESCRIPTION
The feedback logging should post to a HTTP URL defined in the config.