### PR TITLE
[ECO-3440] Remove deprecated chrome.webstore.install

### DIFF
--- a/screen-sharing-extension-chrome/content-script.js
+++ b/screen-sharing-extension-chrome/content-script.js
@@ -43,7 +43,7 @@ window.addEventListener('message', function (event) {
       payload = event.data.payload;
 
   if(!payload.requestId) {
-    console.warn('Message to screen sharing extesnion does not have a requestId for replies.');
+    console.warn('Message to screen sharing extension does not have a requestId for replies.');
     return undefined;
   }
 

--- a/test/unit/roomView_spec.html
+++ b/test/unit/roomView_spec.html
@@ -137,9 +137,9 @@
         </footer>
     </section>
     <section id="extInstallationSuccessful">
-      <header>Chrome extension was installed successfully.</header>
+      <header>You need a Chrome extension to share your screen.</header>
       <hr>
-      <p>You need to refresh your browser in order to use it.</p>
+      <p>Once you have installed it, refresh your browser and click 'share screen' again.</p>
       <footer>
         <button id="scrShrLater" class="btn btn-white btn-padding ctaarrow-blue">Later</button>
         <button id="scrShrReload" class="btn btn-blue btn-padding ctaarrow-white">Reload</button>

--- a/test/unit/screenShareController_spec.js
+++ b/test/unit/screenShareController_spec.js
@@ -144,7 +144,7 @@ describe('ScreenShareController', () => {
      'installation does not work', (done) => {
     var event = new CustomEvent('screenShareView:installExtension');
     var realWindowOpen = window.open;
-    window.open = function () { return null };
+    window.open = () => null;
 
     window.addEventListener('screenShareController:extInstallationResult',
                             function handlerTest(evt) {

--- a/test/unit/screenShareController_spec.js
+++ b/test/unit/screenShareController_spec.js
@@ -128,8 +128,6 @@ describe('ScreenShareController', () => {
   it('should respond correctly to screenShareView:installExtension when ' +
      'installation works', (done) => {
     var event = new CustomEvent('screenShareView:installExtension');
-    window.chrome.isGoingToWork = true;
-
     window.addEventListener('screenShareController:extInstallationResult',
                              function handlerTest(evt) {
                                window.removeEventListener('screenShareController:extInstallationResult', handlerTest);
@@ -145,14 +143,15 @@ describe('ScreenShareController', () => {
   it('should respond correctly to screenShareView:installExtension when ' +
      'installation does not work', (done) => {
     var event = new CustomEvent('screenShareView:installExtension');
-    window.chrome.isGoingToWork = false;
+    var realWindowOpen = window.open;
+    window.open = function () { return null };
 
     window.addEventListener('screenShareController:extInstallationResult',
                             function handlerTest(evt) {
                               window.removeEventListener('screenShareController:extInstallationResult', handlerTest);
                               expect(evt.detail.error).to.be.true;
-                              expect(evt.detail.message).to.be.equal(window.chrome.error);
                               done();
+                              window.open = realWindowOpen;
                             });
 
     ScreenShareController.init('usr', chromeExtId, otHelper).then(() => {

--- a/test/unit/screenShareView_spec.html
+++ b/test/unit/screenShareView_spec.html
@@ -15,9 +15,9 @@
         </footer>
     </section>
     <section id="extInstallationSuccessful">
-      <header>Chrome extension was installed successfully.</header>
+      <header>You need a Chrome extension to share your screen.</header>
       <hr>
-      <p>You need to refresh your browser in order to use it.</p>
+      <p>Once you have installed it, refresh your browser and click 'share screen' again.</p>
       <footer>
         <button id="scrShrLater" class="btn btn-white btn-padding ctaarrow-blue">Later</button>
         <button id="scrShrReload" class="btn btn-blue btn-padding ctaarrow-white">Reload</button>

--- a/test/unit/screenShareView_spec.js
+++ b/test/unit/screenShareView_spec.js
@@ -124,7 +124,7 @@ describe('ScreenShareView', () => {
     testMsgError(event, '', 'successful-installation', done);
   });
 
-  it('should show installation success', (done) => {
+  it('should show installation failure', (done) => {
     var err = {
       error: true,
       message: 'Error message',

--- a/views/min.ejs
+++ b/views/min.ejs
@@ -116,9 +116,9 @@
             </footer>
         </section>
         <section id="extInstallationSuccessful">
-          <header>Chrome extension was installed successfully.</header>
+          <header>You need a Chrome extension to share your screen.</header>
           <hr>
-          <p>You need to refresh your browser in order to use it.</p>
+          <p>Once you have installed it, refresh your browser and click 'share screen' again.</p>
           <footer>
             <button id="scrShrLater" class="btn btn-white btn-padding ctaarrow-blue">Later</button>
             <button id="scrShrReload" class="btn btn-blue btn-padding ctaarrow-white">Reload</button>

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -201,9 +201,9 @@
             </footer>
         </section>
         <section id="extInstallationSuccessful">
-          <header>Chrome extension was installed successfully.</header>
+          <header>You need a Chrome extension to share your screen.</header>
           <hr>
-          <p>You need to refresh your browser in order to use it.</p>
+          <p>Once you have installed it, refresh your browser and click 'share screen' again.</p>
           <footer>
             <button id="scrShrLater" class="btn btn-white btn-padding ctaarrow-blue">Later</button>
             <button id="scrShrReload" class="btn btn-blue btn-padding ctaarrow-white">Reload</button>

--- a/web/js/screenShareController.js
+++ b/web/js/screenShareController.js
@@ -74,21 +74,12 @@
 
   var screenShareViewEvents = {
     installExtension: function () {
-      try {
-        chrome.webstore.install('https://chrome.google.com/webstore/detail/' + _chromeExtId,
-          function () {
-            Utils.sendEvent('screenShareController:extInstallationResult',
-                            { error: false });
-          }, function (err) {
-            Utils.sendEvent('screenShareController:extInstallationResult',
-                            { error: true, message: err });
-          });
-      } catch (e) {
-        // WARNING!! This shouldn't happen
-        // If this message is displayed it could be because the extensionId is not
-        // registred and, in this case, we have a bug because this was already controlled
-        debug.error('Error installing extension:', e);
-      }
+      var newTab = window.open('https://chrome.google.com/webstore/detail/' + _chromeExtId, '_blank');
+      var error = !newTab || typeof newTab !== 'object';
+      Utils.sendEvent('screenShareController:extInstallationResult', {
+        error: error,
+        message: error ? 'It seems you have a Pop-Up blocker enabled. Please disabled it and try again.' : null
+      });
     }
   };
 

--- a/web/js/screenShareController.js
+++ b/web/js/screenShareController.js
@@ -80,7 +80,7 @@
         error: error,
         message: error ? 'It seems you have a Pop-Up blocker enabled. Please disabled it and try again.' : null
       });
-      if (debug) {
+      if (error) {
         debug.error('Error opening Chrome Webstore');
       }
     }

--- a/web/js/screenShareController.js
+++ b/web/js/screenShareController.js
@@ -1,4 +1,4 @@
-/* global RoomView, OTHelper, chrome, ScreenShareView */
+/* global RoomView, OTHelper, ScreenShareView */
 
 !(function (globals) {
   'use strict';
@@ -80,6 +80,9 @@
         error: error,
         message: error ? 'It seems you have a Pop-Up blocker enabled. Please disabled it and try again.' : null
       });
+      if (debug) {
+        debug.error('Error opening Chrome Webstore');
+      }
     }
   };
 

--- a/web/js/screenShareView.js
+++ b/web/js/screenShareView.js
@@ -22,7 +22,7 @@
 
     var installLink = shareError.querySelector('#screenShareErrorInstall button');
     installLink.addEventListener('click', function () {
-      hideShareScreenError();
+      Modal.hide('.screen-modal');
       Utils.sendEvent('screenShareView:installExtension');
     });
     Utils.addEventsHandlers('screenShareController:', screenShareCtrlEvents, exports);


### PR DESCRIPTION
Chrome has deprecated the inline install API method and it will be removed from Chrome 71.
This PR changes a bit the flow so that when the user clicks on `Install extesion` button a new tab to the Chrome WebStore will be created.

The actual modification was done in the file `web/js/screenShareController.js` from line 77. 