### PR TITLE
Create an env var for setting media mode for OT sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ The app lets the developer POST feedback data to an endpoint on your HTTP server
 * `JQUERY_URL` (Optional, default value: 'https://ajax.googleapis.com/ajax/libs/jquery/'):
    Route of the CDN that will be used to load JQuery scripts.
 
+* `MEDIA_MODE` (Optional, default value: 'routed'): Whether the OpenTok sessions should be `relayed` or `routed`.
+
 ## Customizing the UI
 
 For information on how to customize OpenTokRTC's UI, see [CUSTOMIZING-UI.md](CUSTOMIZING-UI.md).

--- a/server/serverConstants.js
+++ b/server/serverConstants.js
@@ -114,3 +114,5 @@ E.GOOGLE_CLIENT_ID = { envVar: 'GOOGLE_CLIENT_ID', jsonPath: 'Google.clientId', 
 E.GOOGLE_HOSTED_DOMAIN = { envVar: 'GOOGLE_HOSTED_DOMAIN', jsonPath: 'Google.hostedDomain', defaultValue: '' };
 
 E.BLACKLIST = { envVar: 'BLACKLIST', jsonPath: 'blacklist', defaultValue: '' };
+
+E.MEDIA_MODE = { envVar: 'MEDIA_MODE', jsonPath: 'mediaMode', defaultValue: 'routed'};

--- a/server/serverMethods.js
+++ b/server/serverMethods.js
@@ -120,6 +120,7 @@ function ServerMethods(aLogLevel, aModules) {
       var sipRequireGoogleAuth = config.get(C.SIP_REQUIRE_GOOGLE_AUTH);
       var googleId = config.get(C.GOOGLE_CLIENT_ID);
       var googleHostedDomain = config.get(C.GOOGLE_HOSTED_DOMAIN);
+      var mediaMode = config.get(C.MEDIA_MODE);
 
       if (sipRequireGoogleAuth) {
         googleAuth = new GoogleAuth.EnabledGoogleAuthStrategy(googleId, googleHostedDomain);
@@ -206,6 +207,7 @@ function ServerMethods(aLogLevel, aModules) {
                 reportIssueLevel,
                 useGoogleFonts,
                 jqueryUrl,
+                mediaMode,
               }));
     });
   }
@@ -406,7 +408,7 @@ function ServerMethods(aLogLevel, aModules) {
 
       if (!aSessionInfo || aSessionInfo.lastUsage <= minLastUsage) {
         // We need to create a new session...
-        var sessionOptions = { mediaMode: 'routed' };
+        var sessionOptions = { mediaMode };
         if (aArchiveAlways) {
           sessionOptions.archiveMode = 'always';
         }


### PR DESCRIPTION
This PR adds an optional env variable that allows the media mode of OT sessions to be set. However, this does not apply to the precall test since we use `routed` mode for those.