### PR TITLE
ECO-4835 - Fix display of FAQ and COVID links on mobile browser

### DIFF
--- a/web/less/landing.less
+++ b/web/less/landing.less
@@ -230,7 +230,7 @@ body {
     @media @smartphones {
       position: fixed;
       right: 20px;
-      bottom: 0;
+      bottom: 42px;
     }
 
     a {
@@ -272,10 +272,18 @@ body {
     .flex(1);
     position: relative;
     width: 305px;
+    min-height: 420px; // fix for Safari flex issue
     @media @smartphonesPortrait {
       margin-right: 0;
       width: 100%;
       height: 100%;
+      header {
+        margin-left: 12px;
+        p {
+          text-align: left;
+          margin-right: 50px;
+        }
+      }
     }
   }
 
@@ -334,6 +342,9 @@ body {
 
         a {
           color: #ffffff; 
+        }
+        @media @smartphones {
+          padding: 0 10px;
         }
       }
     }


### PR DESCRIPTION
Note that this also fixes a couple of other issues:
* In the landing page more than just the links were screwed up on mobile. 
* The links overlapping in Safari desktop when you shrink the window vertically.