### PR TITLE
[ECO-5245] Remove oldVersionCompat server method

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -18,7 +18,6 @@ produces:
 x-implementation-module: serverMethods.js
 x-implementation-middleware:
   - configReady
-  - oldVersionCompat
   - iframingOptions
   - featureEnabled
 x-implementation-configuration: loadConfig

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-rtc",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "OpenTokRTC sample application to show off the OpenTok API and platform capabilities ",
   "main": "server.js",
   "engines": {

--- a/server/serverMethods.js
+++ b/server/serverMethods.js
@@ -778,20 +778,6 @@ function ServerMethods(aLogLevel, aModules) {
     return tbConfigPromise;
   }
 
-  function oldVersionCompat(aReq, aRes, aNext) {
-    if (!aReq.tbConfig.isWebRTCVersion) {
-      aNext();
-      return;
-    }
-    var matches = aReq.path.match(/^\/([^/]+)\.json$/);
-    if (matches) {
-      aReq.url = '/room/' + matches[1] + '/info';
-      aReq.sessionIdField = 'sid';
-      logger.log('oldVersionCompat: Rewrote path to: ' + aReq.url);
-    }
-    aNext();
-  }
-
   // /health
   // Checks the ability to connect to external services used by the app
   function getHealth(aReq, aRes) {
@@ -876,7 +862,6 @@ function ServerMethods(aLogLevel, aModules) {
     postRoomDial,
     postHangUp,
     getHealth,
-    oldVersionCompat,
     saveConnectionFirebase,
     deleteConnectionFirebase,
   };


### PR DESCRIPTION
**What is this PR doing?**

It removes the oldVersionCompat server method which was exposing config data.