### PR TITLE
Remove oldVersionCompat server method

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -19,7 +19,6 @@ x-implementation-module: serverMethods.js
 x-implementation-middleware:
   - setSecurityHeaders
   - configReady
-  - oldVersionCompat
   - iframingOptions
   - featureEnabled
 x-implementation-configuration: loadConfig

--- a/server/serverMethods.js
+++ b/server/serverMethods.js
@@ -1017,20 +1017,6 @@ function ServerMethods(aLogLevel, aModules) {
     return tbConfigPromise;
   }
 
-  function oldVersionCompat(aReq, aRes, aNext) {
-    if (!aReq.tbConfig.isWebRTCVersion) {
-      aNext();
-      return;
-    }
-    var matches = aReq.path.match(/^\/([^/]+)\.json$/);
-    if (matches) {
-      aReq.url = '/room/' + matches[1] + '/info';
-      aReq.sessionIdField = 'sid';
-      logger.log('oldVersionCompat: Rewrote path to: ' + aReq.url);
-    }
-    aNext();
-  }
-
   // /health
   // Checks the ability to connect to external services used by the app
   function getHealth(aReq, aRes) {
@@ -1128,7 +1114,6 @@ function ServerMethods(aLogLevel, aModules) {
     postRoomDial,
     postHangUp,
     getHealth,
-    oldVersionCompat,
     getRoomRawInfo,
     saveConnectionFirebase,
     deleteConnectionFirebase,


### PR DESCRIPTION
**What is this PR doing?**
This PR removes the route with the pattern /{file}.json which was exposing config data.

This is part of the ticket [https://tokbox.atlassian.net/browse/ECO-5245](https://tokbox.atlassian.net/browse/ECO-5245)