### PR TITLE
Add config options for the intro text footer link

### DIFF
--- a/CUSTOMIZING-UI.md
+++ b/CUSTOMIZING-UI.md
@@ -31,6 +31,8 @@ These can be configured with these settings:
 
 * `appName` (config.json) / `APP_NAME` (environment variable)
 * `introText` (config.json) / `INTRO_TEXT` (environment variable)
+* `introFooterLinkText` (config.json) / `INTRO_FOOTER_LINK_TEXT` (environment variable)
+* `introFooterLinkUrl` (config.json) / `INTRO_FOOTER_LINK_URL` (environment variable)
 * `helpLinkText1` (config.json) / `HELP_LINK_TEXT_1` (environment variable)
 * `helpLinkUrl1` (config.json) / `HELP_LINK_URL_1` (environment variable)
 * `helpLinkText2` (config.json) / `HELP_LINK_TEXT_2` (environment variable)

--- a/README.md
+++ b/README.md
@@ -571,7 +571,14 @@ To configure this, edit options in the config/config.json file or set environmen
   The default value is 'Vonage Video Conferencing'.
 
 * `introText` (config.json) / `INTRO_TEXT` (environment variable) -- The text displayed under
-  the application name in the precall widget. The default value is 'Welcome to Video Conferencing'
+  the application name in the precall widget. The default value is 'Welcome to Video Conferencing'.
+
+* `introFooterLinkText` (config.json) / `INTRO_FOOTER_LINK_TEXT` (environment variable) -- The text
+  for the optional link displayed under the intro text in the precall widget. If no value is
+  specified (or if it is set the an empty string), no link is displayed. The default value is ''.
+
+* `introFooterLinkUrl` (config.json) / `INTRO_FOOTER_LINK_URL` (environment variable) -- The URL
+  for the optional link displayed under the intro text in the precall widget. The default value is ''.
 
 * `helpLinkText1` (config.json) / `HELP_LINK_TEXT_1` (environment variable) -- The text
   for the first help link displayed after "Need help?" at the top of the precall widget.

--- a/config/example.json
+++ b/config/example.json
@@ -47,6 +47,8 @@
   "autoGenerateRoomName": true,
   "appName": "Vonage Video Conferencing",
   "introText": "Welcome to Video Conferencing.",
+  "introFooterLinkText": "",
+  "introFooterLinkUrl": "",
   "helpLinkText1": "",
   "helpLinkUrl1": "",
   "helpLinkText2": "",

--- a/server/serverConstants.js
+++ b/server/serverConstants.js
@@ -176,9 +176,13 @@ E.BLACKLIST = { envVar: 'BLACKLIST', jsonPath: 'blacklist', defaultValue: '' };
 
 E.MEDIA_MODE = { envVar: 'MEDIA_MODE', jsonPath: 'mediaMode', defaultValue: 'routed' };
 
+E.APP_NAME = { envVar: 'APP_NAME', jsonPath: 'appName', defaultValue: 'Vonage Video Conferencing' };
+
 E.INTRO_TEXT = { envVar: 'INTRO_TEXT', jsonPath: 'introText', defaultValue: 'Welcome to Video Conferencing.' };
 
-E.APP_NAME = { envVar: 'APP_NAME', jsonPath: 'appName', defaultValue: 'Vonage Video Conferencing' };
+E.INTRO_FOOTER_LINK_TEXT = { envVar: 'INTRO_FOOTER_LINK_TEXT', jsonPath: 'introFooterLinkText', defaultValue: '' };
+
+E.INTRO_FOOTER_LINK_URL = { envVar: 'INTRO_FOOTER_LINK_URL', jsonPath: 'introFooterLinkUrl', defaultValue: '' };
 
 E.HELP_LINK_TEXT_1 = { envVar: 'HELP_LINK_TEXT_1', jsonPath: 'helpLinkText1', defaultValue: '' };
 

--- a/server/serverMethods.js
+++ b/server/serverMethods.js
@@ -197,6 +197,8 @@ function ServerMethods(aLogLevel, aModules) {
       const enableFeedback = config.get(C.ENABLE_FEEDBACK);
       const autoGenerateRoomName = config.get(C.AUTO_GENERATE_ROOM_NAME);
       const introText = config.get(C.INTRO_TEXT);
+      const introFooterLinkText = config.get(C.INTRO_FOOTER_LINK_TEXT);
+      const introFooterLinkUrl = config.get(C.INTRO_FOOTER_LINK_URL);
       const appName = config.get(C.APP_NAME);
       const helpLinkText1 = config.get(C.HELP_LINK_TEXT_1);
       const helpLinkUrl1 = config.get(C.HELP_LINK_URL_1);
@@ -266,6 +268,8 @@ function ServerMethods(aLogLevel, aModules) {
         enableEmoji,
         autoGenerateRoomName,
         introText,
+        introFooterLinkText,
+        introFooterLinkUrl,
         appName,
         helpLinkText1,
         helpLinkUrl1,
@@ -492,6 +496,8 @@ function ServerMethods(aLogLevel, aModules) {
             enableFeedback: tbConfig.enableFeedback,
             enterButtonLabel: 'Join Meeting',
             introText: tbConfig.introText,
+            introFooterLinkText: tbConfig.introFooterLinkText,
+            introFooterLinkUrl: tbConfig.introFooterLinkUrl,
             appName: tbConfig.appName,
             helpLinkText1: tbConfig.helpLinkText1,
             helpLinkUrl1: tbConfig.helpLinkUrl1,

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -85,6 +85,8 @@
       window.publishAudio = <%=publishAudio%>;
       window.publishVideo = <%=publishVideo%>;
       window.introText='<%=introText%>';
+      window.introFooterLinkText='<%=introFooterLinkText%>';
+      window.introFooterLinkUrl='<%=introFooterLinkUrl%>';
       window.appName='<%=appName%>';
       window.helpLinkText1='<%=helpLinkText1%>';
       window.helpLinkUrl1='<%=helpLinkUrl1%>';

--- a/web/templates/precall.ejs
+++ b/web/templates/precall.ejs
@@ -17,9 +17,11 @@
         <%=introText%>
       </p>
     </header>
+    <% if (introFooterLinkText) { %>
     <footer>
-      <a href="https://www.vonage.com/solutions/" target="_blank" rel="noopener">Solutions for when the unexpected happens</a>
+      <a href="<%=introFooterLinkUrl%>" target="_blank" rel="noopener"><%=introFooterLinkText%></a>
     </footer>
+    <% } %>
 </div>
 <div id="righthand-container" class="user-name-modal">
   <div class="landing-more-info">


### PR DESCRIPTION
For example, see the "Solutions for when the unexpected happens" link at https://freeconferencing.vonage.com/ (which does not appear at http://opentokdemo.tokbox.com/).