### PR TITLE
VIDSOL-1133: Fixed permissions

### DIFF
--- a/.github/workflows/delete-closed-pr.yml
+++ b/.github/workflows/delete-closed-pr.yml
@@ -2,10 +2,15 @@ name: delete branch on close pr
 on: 
   pull_request:
     types: [closed]
-  
+
+permissions:
+  contents: read
+
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: delete branch
         uses: SvanBoxel/delete-merged-branch@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   recordMetrics:
     runs-on: ubuntu-latest

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   recordMetrics:
     runs-on: ubuntu-latest


### PR DESCRIPTION
  - main.yml and metrics.yml — Added top-level permissions: contents: read. These workflows only read repo metadata for metrics collection, so no write access is needed.
  - delete-closed-pr.yml — Added top-level permissions: contents: read (restrictive default), then elevated the delete-branch job to permissions: contents: write since it needs to delete the merged branch. This keeps the principle of least privilege while preserving the job's functionality.