### PR TITLE
feat: add tier tags to service catalog entries

### DIFF
--- a/.vonage/catalog-info.yaml
+++ b/.vonage/catalog-info.yaml
@@ -6,6 +6,8 @@ metadata:
   description: OpentokRTC is an open-source, web-based video conferencing solution built on the OpenTok API. It serves as a private video conferencing application that can be deployed on customers servers
   annotations:
     vonage.com/jira-id: VPF # video general projects
+  tags:
+    - tier2
 spec:
   type: library
   owner: group:orgdata/vdk # helm "owner" orgdata squad id or general orgdata/vid


### PR DESCRIPTION
This PR is part of APISPOG-291 work and adds tier tags to the following System entities in the service catalog:

- `tier2` → **video-opentok-rtc** (service: video-opentok-rtc)

Please review and merge this PR to ensure the service catalog is up to date with the correct tier information. If you think the Service Tier isn't correct, contact Karen Szymczyk.